### PR TITLE
let RestKitMapper work with latest RestKit 0.27

### DIFF
--- a/Classes/RKMRestKitMapper.h
+++ b/Classes/RKMRestKitMapper.h
@@ -13,7 +13,7 @@ extern NSString * const RKMRestKitMapperConfigFileKey;
 extern NSString * const RKMRestKitMapperServerBaseKey;
 extern NSString * const RKMRestKitMapperContextUrlKey;
 
-@class AFHTTPClient;
+@class AFRKHTTPClient;
 
 /**
  Helper class providing declarative-style RestKit configuration using property files
@@ -77,6 +77,6 @@ typedef void (^RKMRequestFailure)(NSError *error);
  
  @return shared HTTPClient instance
  */
-- (AFHTTPClient*)HTTPClient;
+- (AFRKHTTPClient*)HTTPClient;
 
 @end

--- a/Classes/RKMRestKitMapper.m
+++ b/Classes/RKMRestKitMapper.m
@@ -100,14 +100,14 @@ NSString * const RKMRestKitMapperContextUrlKey = @"RestKitMapperContextUrl";
 {
     RKObjectManager *manager = [RKObjectManager sharedManager];
     manager.requestSerializationMIMEType = RKMIMETypeJSON;
-    [manager setHTTPClient:[AFHTTPClient clientWithBaseURL:url]];
+    [manager setHTTPClient:[AFRKHTTPClient clientWithBaseURL:url]];
     [self setupHttpClient];
 
     for (RKResponseDescriptor *responseDescriptor in [RKObjectManager sharedManager].responseDescriptors)
         [responseDescriptor setBaseURL:[RKObjectManager sharedManager].baseURL];
 }
 
-- (AFHTTPClient *)HTTPClient
+- (AFRKHTTPClient *)HTTPClient
 {
     return [RKObjectManager sharedManager].HTTPClient;
 }
@@ -280,8 +280,8 @@ static NSDictionary *fetchRequestMappings = nil;
 -(void)setupHttpClient
 {
     RKObjectManager *manager = [RKObjectManager sharedManager];
-    [manager.HTTPClient registerHTTPOperationClass:[AFJSONRequestOperation class]];
-    [manager.HTTPClient setParameterEncoding:AFJSONParameterEncoding];
+    [manager.HTTPClient registerHTTPOperationClass:[AFRKJSONRequestOperation class]];
+    [manager.HTTPClient setParameterEncoding:AFRKJSONParameterEncoding];
     [manager.HTTPClient setDefaultHeader:@"Accept" value:@"application/json"];
     [manager.HTTPClient setDefaultHeader:@"Content-Type" value:@"application/json"];
     [manager setAcceptHeaderWithMIMEType:RKMIMETypeJSON];
@@ -350,7 +350,7 @@ static NSDictionary *fetchRequestMappings = nil;
     [RKObjectManager setSharedManager:objectManager];
 
     // Enable Activity Indicator Spinner
-    [AFNetworkActivityIndicatorManager sharedManager].enabled = YES;
+    [AFRKNetworkActivityIndicatorManager sharedManager].enabled = YES;
 
     NSMutableDictionary *fetchRequestsDict = [NSMutableDictionary dictionary];
 

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,5 @@
-platform :ios, '7.0'
+platform :ios, '8.0'
 inhibit_all_warnings!
-pod 'RestKit'
+#pod 'RestKit'
+#RestKit 0.27.1 with iOS10 fix
+pod 'RestKit', :git => 'https://github.com/RestKit/RestKit.git', :commit => '13d98d5a6a5e06656ad040013dcae149b7cf8b99'

--- a/RestKitMapper.podspec
+++ b/RestKitMapper.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "RestKitMapper"
-  s.version          = "0.1.1"
+  s.version          = "0.1.2
   s.summary          = "Declarative-style configurator for RestKit."
   s.description      = <<-DESC
                        RestKitMapper allows to perform declarative-style configuration of RestKit
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/xfyre/RestKitMapper.git", :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '8.0'
   s.requires_arc = true
 
   s.source_files = 'Classes'

--- a/RestKitMapper.podspec
+++ b/RestKitMapper.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "RestKitMapper"
-  s.version          = "0.1.2
+  s.version          = "0.1.2"
   s.summary          = "Declarative-style configurator for RestKit."
   s.description      = <<-DESC
                        RestKitMapper allows to perform declarative-style configuration of RestKit


### PR DESCRIPTION
RestKitMapper does not work with latest RestKit 0.27, here is the fix.

Actually there is a problem with RestKit on iOS 10, which is fixed in not yet released 0.27.1, see:
https://github.com/RestKit/RestKit/pull/2449
https://github.com/RestKit/RestKit/issues/2451

That's why I'm using this in Podfile:
pod 'RestKit', :git => 'https://github.com/RestKit/RestKit.git', :commit => '13d98d5a6a5e06656ad040013dcae149b7cf8b99'